### PR TITLE
Normalize design system: HSBC crimson accent, dark mode, Bootstrap 5.3 consistency

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Webpack Dev Server (start)",
+      "runtimeExecutable": "/Users/barryg/.nvm/versions/node/v22.9.0/bin/node",
+      "runtimeArgs": ["/Users/barryg/Git/hsbc-web-app/node_modules/.bin/webpack", "serve", "--mode", "development"],
+      "port": 8080
+    },
+    {
+      "name": "Webpack Dev Server (develop)",
+      "runtimeExecutable": "/Users/barryg/.nvm/versions/node/v22.9.0/bin/node",
+      "runtimeArgs": ["/Users/barryg/Git/hsbc-web-app/node_modules/webpack-dev-server/bin/webpack-dev-server.js", "--mode", "development"],
+      "port": 8080
+    }
+  ]
+}

--- a/.github/workflows/azure-static-web-apps-orange-pond-0298a3600.yml
+++ b/.github/workflows/azure-static-web-apps-orange-pond-0298a3600.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Build And Deploy

--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,23 @@
+## Design Context
+
+### Users
+Finance and accounting team members who process HSBC credit card statements for import into Xero. Used regularly in a professional context. Users are familiar with financial software and expect reliability — they are not the general public.
+
+### Brand Personality
+Professional, trustworthy, calm. The tool handles financial data, so confidence and clarity take priority over delight. Think: well-built internal finance tool, not a consumer app.
+
+Three words: **precise, dependable, clean**
+
+### Aesthetic Direction
+- **Accent colour**: HSBC-inspired muted crimson (`#c41230`) as the primary brand accent. Used sparingly — on the primary action, key interactive states — not decoratively.
+- **Neutrals**: Warm-tinted, not cold blue-grays. Body background slightly off-white (`#fafaf9`) in light mode.
+- **Theme**: Responds to system `prefers-color-scheme`. No manual toggle needed.
+- **Tone**: Structured whitespace. Financial data needs breathing room and clear hierarchy. Calm and considered, not flashy.
+- **Anti-references**: Avoid anything that looks like a consumer SaaS dashboard — hero metrics, gradient banners, icon-above-heading templates. This is a utility, not a product page.
+
+### Design Principles
+1. **Trust through clarity** — every state is explicit and visible. Errors, loading, success — nothing is ambiguous.
+2. **Minimal footprint** — one job, done well. The UI exists to support the task, not to assert itself.
+3. **Purposeful colour** — HSBC crimson appears only on the primary action and key interactive moments. Never decorative.
+4. **Structured warmth** — warm-tinted neutrals and generous spacing make data legible without feeling cold or clinical.
+5. **System-aware** — respects the user's OS light/dark preference without requiring any manual toggle.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+## Design Context
+
+### Users
+Finance and accounting team members who process HSBC credit card statements for import into Xero. Used regularly in a professional context. Users are familiar with financial software and expect reliability — they are not the general public.
+
+### Brand Personality
+Professional, trustworthy, calm. The tool handles financial data, so confidence and clarity take priority over delight. Think: well-built internal finance tool, not a consumer app.
+
+Three words: **precise, dependable, clean**
+
+### Aesthetic Direction
+- **Accent colour**: HSBC-inspired muted crimson (`#c41230`) as the primary brand accent. Used sparingly — on the primary action, key interactive states — not decoratively.
+- **Neutrals**: Warm-tinted, not cold blue-grays. Body background slightly off-white (`#fafaf9`) in light mode.
+- **Theme**: Responds to system `prefers-color-scheme`. No manual toggle needed.
+- **Tone**: Structured whitespace. Financial data needs breathing room and clear hierarchy. Calm and considered, not flashy.
+- **Anti-references**: Avoid anything that looks like a consumer SaaS dashboard — hero metrics, gradient banners, icon-above-heading templates. This is a utility, not a product page.
+
+### Design Principles
+1. **Trust through clarity** — every state is explicit and visible. Errors, loading, success — nothing is ambiguous.
+2. **Minimal footprint** — one job, done well. The UI exists to support the task, not to assert itself.
+3. **Purposeful colour** — HSBC crimson appears only on the primary action and key interactive moments. Never decorative.
+4. **Structured warmth** — warm-tinted neutrals and generous spacing make data legible without feeling cold or clinical.
+5. **System-aware** — respects the user's OS light/dark preference without requiring any manual toggle.

--- a/src/_custom.scss
+++ b/src/_custom.scss
@@ -1,0 +1,10 @@
+// Use CSS media queries for automatic dark/light mode (no JS needed)
+// Bootstrap will use @media (prefers-color-scheme: dark) instead of [data-bs-theme="dark"]
+$color-mode-type: media;
+
+// HSBC-inspired muted crimson as the primary brand accent
+$primary: #c41230;
+
+// Warm-tinted body colours — avoids the cold blue-gray of Bootstrap defaults
+$body-bg: #fafaf9;
+$body-color: #1c1917;

--- a/src/createSampleTable.ts
+++ b/src/createSampleTable.ts
@@ -9,7 +9,7 @@ export function createSampleTable(csvData: string[][]): HTMLElement {
     // No transaction rows — return an empty state message
     if (csvData.length === 1) {
         const empty = document.createElement('p');
-        empty.className = 'text-muted fst-italic';
+        empty.className = 'text-body-secondary fst-italic';
         empty.textContent = 'No transaction rows found.';
         return empty;
     }
@@ -17,7 +17,7 @@ export function createSampleTable(csvData: string[][]): HTMLElement {
     const table = document.createElement("table");
     assertNotNull(table);
     table.id = "sample-data";
-    table.className = "table table-striped table-bordered mb-3";
+    table.className = "table table-striped table-bordered table-hover mb-3";
 
     // Create proper table structure
     const thead = document.createElement("thead");

--- a/src/handleSubmit.ts
+++ b/src/handleSubmit.ts
@@ -67,7 +67,7 @@ export const handleSubmit =
             const rowCount = csvData.length - 1;
             const previewCount = Math.min(rowCount, 19);
             const summary = document.createElement('p');
-            summary.className = 'text-muted';
+            summary.className = 'text-body-secondary mb-3';
             summary.textContent = rowCount === 0
                 ? 'No transactions found in the file.'
                 : `Processed ${rowCount} transaction${rowCount !== 1 ? 's' : ''}. Showing first ${previewCount} row${previewCount !== 1 ? 's' : ''}.`;
@@ -75,6 +75,7 @@ export const handleSubmit =
 
             // Sample data section
             const sampleHeading = document.createElement('h2');
+            sampleHeading.className = 'mb-3';
             sampleHeading.textContent = 'Sample data';
             container.appendChild(sampleHeading);
             container.appendChild(createSampleTable(csvData));
@@ -87,7 +88,7 @@ export const handleSubmit =
             const downloadLink = document.createElement('a');
             downloadLink.href = url;
             downloadLink.download = 'processed.csv';
-            downloadLink.className = 'btn btn-primary mt-2';
+            downloadLink.className = 'btn btn-primary mt-3';
             downloadLink.textContent = 'Download File';
             downloadLink.addEventListener('click', () => {
                 setTimeout(() => URL.revokeObjectURL(url), 100);

--- a/src/index.html
+++ b/src/index.html
@@ -3,27 +3,25 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>HSBC Xero Processor</title>
+  <title>HSBC → Xero CSV Converter</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <!-- load source image -->
+  <meta name="description" content="Convert HSBC credit card CSV statements to Xero-compatible format.">
   <link href="./favicon.png" rel="icon" />
-  <!-- load source style -->
   <link href="./index.scss" rel="stylesheet" />
-  <!-- load source script -->
   <script src="./index.ts" defer="defer"></script>
 </head>
 
 <body>
-  <div class="container-fluid" id="top-container">
+  <div class="container py-5 px-4" id="top-container">
     <main role="main">
-      <h1>HSBC CC Statement Processor</h1>
-      <form id="fileSelect" class="bg-light mb-3">
+      <h1 class="mb-4">HSBC CC Statement Processor</h1>
+      <form id="fileSelect" class="bg-body-secondary p-4 rounded-3 mb-4">
         <div class="mb-3">
-          <label for="formFile" class="form-label h5">Select HSBC CC Statement</label>
+          <label for="formFile" class="form-label fw-semibold">Select HSBC CC Statement</label>
           <input class="form-control" type="file" id="formFile" accept=".csv,text/csv">
         </div>
-        <div class="mb-3">
-          <input class="btn btn-success" type="submit" value="Process File">
+        <div class="mb-0">
+          <input class="btn btn-primary" type="submit" value="Process File">
         </div>
       </form>
       <div id="output-region" aria-live="polite"></div>


### PR DESCRIPTION
## Summary

- **`_custom.scss`**: Override Bootstrap `$primary` with HSBC-inspired crimson (`#c41230`), set `$color-mode-type: media` for automatic `prefers-color-scheme` dark/light switching, warm-tinted body neutrals
- **`index.html`**: Container padding, form background → `bg-body-secondary` (dark-mode-aware), proper internal padding and rounded corners, label class fixed (`h5` → `fw-semibold`), submit button → `btn-primary` (brand colour), improved page title and meta description
- **`handleSubmit.ts` / `createSampleTable.ts`**: `text-muted` → `text-body-secondary` (Bootstrap 5.3, adapts to dark mode), `table-hover` added, spacing adjustments
- **`.impeccable.md` + `CLAUDE.md`**: Design context captured — HSBC crimson accent, professional/trustworthy tone, system dark mode, warm neutrals
- **`.claude/launch.json`**: Dev server config for `preview_start`

## Test plan

- [ ] Light mode: button is HSBC crimson, background is warm off-white, form has padding and rounded corners
- [ ] Dark mode (toggle OS preference): page switches automatically, all colours adapt correctly
- [ ] Upload a valid HSBC CSV — transaction count, sample table, and download button all render correctly
- [ ] Upload with no file — red alert shows "No file selected"
- [ ] `preview_start` starts the webpack dev server correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)